### PR TITLE
Improve lay-out for menu planning

### DIFF
--- a/recipe-front-end/src/App.scss
+++ b/recipe-front-end/src/App.scss
@@ -149,10 +149,22 @@ li {
   clear: both;
 }
 
+.menu-selected-day {
+  clear: both;
+  background-color: #EDF2F7;
+  padding: 1em;
+  border: 2px solid #E2E8F0;
+
+  a {
+    display: block;
+    margin-top: em;
+  }
+}
+
 .day {
   width: 100%;
   float: left;
-  border: 1px solid lightgray;
+  border: 1px solid #F7FAFC;
   height: 100%;
 
   img {
@@ -170,8 +182,10 @@ li {
   }
 }
 
-.current-day {
-  background-color: lightgreen;
+.selected-day {
+  background-color: #E2E8F0;
+  border: 2px solid #E2E8F0;
+  border-bottom: none;
 }
 
 .search-result {

--- a/recipe-front-end/src/components/menu-planner/Day.tsx
+++ b/recipe-front-end/src/components/menu-planner/Day.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Tooltip, useMediaQuery } from "@chakra-ui/react";
+import { Tooltip, useMediaQuery } from "@chakra-ui/react";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useState } from "react";
@@ -7,17 +7,17 @@ import { Recipe } from "../../interfaces/Recipe";
 import { Localisation } from "../../localisation/AppTexts";
 import { addMenu } from "../../redux/Actions";
 import { DayMenu, ReduxModel } from "../../redux/Store";
-import { FULL_DAY_IN_MS } from "../../utils/DateUtils";
 import { AddMenyOverlay } from "./AddMenuOverlay";
 
 interface OwnProps {
     date: Date;
     isCurrentDay: boolean;
     dayOfWeek: number;
+    menuOfTheDay: DayMenu[];
+    onFocus(): void;
 }
 
 interface ReduxProps {
-    menuOfTheDay: DayMenu[];
     recipes: Recipe[];
 }
 
@@ -25,18 +25,9 @@ interface ReduxActionProps {
     addMenu: typeof addMenu;
 }
 
-function filterForDate(menus: DayMenu[], forDate: Date): DayMenu[] {
-    const fromTime = new Date(forDate.getFullYear(), forDate.getMonth(), forDate.getDate()).getTime();
-    const toTime = fromTime + FULL_DAY_IN_MS;
-
-    return menus.filter((item) => {
-        return item.date >= fromTime && item.date < toTime;
-    });
-}
 
 function mapStateToProps(reduxStore: ReduxModel, ownProps: OwnProps): ReduxProps {
     return {
-        menuOfTheDay: filterForDate(reduxStore.menuPlanning, ownProps.date),
         recipes: reduxStore.recipes
     };
 }
@@ -44,7 +35,7 @@ function mapStateToProps(reduxStore: ReduxModel, ownProps: OwnProps): ReduxProps
 type Props = OwnProps & ReduxProps & ReduxActionProps;
 
 function Day(props: Props) {
-    const classes = `day ${props.isCurrentDay ? 'current-day' : ''}`;
+    const classes = `day ${props.isCurrentDay ? 'selected-day' : ''}`;
     const [isSmallView] = useMediaQuery("(max-width: 40em)");
     const dishedDescription = (props.menuOfTheDay.length === 1)
         ? Localisation.DISH_SINGULAR
@@ -52,22 +43,22 @@ function Day(props: Props) {
     const hasRecipes = Boolean(props.menuOfTheDay.length);
     const [isOpened, setIsOpened] = useState(false);
 
-    return (<Box className={classes}>
-        <Box className='planner-day-display'>{props.date.getDate()}</Box>
-        <Box>
+    return (<div className={classes} onMouseEnter={() => props.onFocus()}>
+        <div className='planner-day-display'>{props.date.getDate()}</div>
+        <div>
             {!isSmallView && (<Tooltip label={props.menuOfTheDay.map((menu) => menu.recipe.title).join('')} fontSize="md">
-                <Center>{hasRecipes ? `${props.menuOfTheDay.length} ${dishedDescription.toLowerCase()}` : '-'}</Center>
+                {hasRecipes ? `${props.menuOfTheDay.length} ${dishedDescription.toLowerCase()}` : '-'}
             </Tooltip>)}
 
-            {isSmallView && (<Center>
-                {props.menuOfTheDay.map((menu, index) => <Box key={index}>{menu.recipe.title}</Box>)}
-            </Center>)}
+            {isSmallView && (<div>
+                {props.menuOfTheDay.map((menu, index) => <div key={index}>{menu.recipe.title}</div>)}
+            </div>)}
 
-            <Center>
+            {isSmallView && (<div>
                 <a href='#' onClick={() => setIsOpened(true)}><FontAwesomeIcon icon={faPlus} />
                     {Localisation.ADD}
                 </a>
-            </Center>
+            </div>)}
 
             <AddMenyOverlay isOpened={isOpened}
                 date={props.date}
@@ -80,8 +71,8 @@ function Day(props: Props) {
                     });
                 }}
                 onCancel={() => setIsOpened(false)} />
-        </Box>
-    </Box>);
+        </div>
+    </div>);
 }
 
 export default connect(mapStateToProps, { addMenu })(Day);

--- a/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
+++ b/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
@@ -1,24 +1,42 @@
-import { Box, CloseButton, Heading, SlideFade } from "@chakra-ui/react";
-import React from "react";
+import { Box, CloseButton, Heading, SlideFade, useMediaQuery } from "@chakra-ui/react";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useEffect, useRef, useState } from "react";
 import { connect } from "react-redux";
+import { Recipe } from "../../interfaces/Recipe";
 import { Localisation } from "../../localisation/AppTexts";
-import { changeActiveView } from '../../redux/Actions';
-import { ReduxModel, ViewType } from "../../redux/Store";
+import { addMenu, changeActiveView } from '../../redux/Actions';
+import { DayMenu, ReduxModel, ViewType } from "../../redux/Store";
 import { calculateStartOfDate, FULL_DAY_IN_MS } from "../../utils/DateUtils";
+import { AddMenyOverlay } from "./AddMenuOverlay";
 import Day from "./Day";
 
 interface OwnProps {
     loggedIn: boolean;
+    menus: DayMenu[];
+    recipes: Recipe[];
 }
 
 interface ReduxProps {
     changeActiveView: typeof changeActiveView;
+    addMenu: typeof addMenu;
 }
 
 function mapStateToProps(store: ReduxModel): OwnProps {
     return {
-        loggedIn: store.user.loggedIn
+        loggedIn: store.user.loggedIn,
+        menus: store.menuPlanning,
+        recipes: store.recipes
     }
+}
+
+function filterForDate(menus: DayMenu[], forDate: Date): DayMenu[] {
+    const fromTime = new Date(forDate.getFullYear(), forDate.getMonth(), forDate.getDate()).getTime();
+    const toTime = fromTime + FULL_DAY_IN_MS;
+
+    return menus.filter((item) => {
+        return item.date >= fromTime && item.date < toTime;
+    });
 }
 
 const WEEKDAYS = [Localisation.MONDAY, Localisation.TUESDAY, Localisation.WEDNESDAY, Localisation.THURSDAY, Localisation.FRIDAY, Localisation.SATURDAY, Localisation.SUNDAY];
@@ -30,6 +48,38 @@ function MenuPlanner(props: Props) {
     const rawCurrentDay = currentDay.getDay();
     const currentWeekDay = rawCurrentDay === 0 ? 6 : currentDay.getDay() - 1;
     const firstDayOfCurrentWeek = currentDay.getTime() - (FULL_DAY_IN_MS * currentWeekDay);
+    const [focusedDay, setFocusedDay] = useState(0);
+    const calculatedFocusedDay = firstDayOfCurrentWeek + (focusedDay * FULL_DAY_IN_MS);
+    const focusedRecipes = filterForDate(props.menus, new Date(calculatedFocusedDay));
+    const [isSmallView] = useMediaQuery("(max-width: 40em)");
+    const [isOpened, setIsOpened] = useState(false);
+    const currentDayFocus = useRef<HTMLAnchorElement>(null);
+
+    useEffect(() => {
+        function switchDay(event: KeyboardEvent) {
+            if (isOpened) {
+                return;
+            }
+
+            let newIndex = focusedDay;
+            if (event.code === 'ArrowLeft') {
+                newIndex = Math.max(newIndex - 1, 0);
+            } else if (event.code === 'ArrowRight') {
+                newIndex = Math.min(newIndex + 1, 6);
+            } else {
+                return;
+            }
+
+            currentDayFocus.current!.focus();
+            setFocusedDay(newIndex);
+        }
+
+        document.body.addEventListener('keyup', switchDay);
+
+        return (() => {
+            document.body.removeEventListener('keyup', switchDay);
+        })
+    })
 
     return (<Box>
         <CloseButton className="close-button-top-left" autoFocus={true} size="md" onClick={() => props.changeActiveView(ViewType.Overview, undefined)} />
@@ -39,13 +89,42 @@ function MenuPlanner(props: Props) {
                 <Box className='week'>
                     {WEEKDAYS.map((day, index) => {
                         const date = new Date(firstDayOfCurrentWeek + (FULL_DAY_IN_MS * index));
+                        const menu = filterForDate(props.menus, date);
                         return (<Day
                             key={index}
                             date={date}
                             dayOfWeek={index}
-                            isCurrentDay={index === currentWeekDay}
+                            menuOfTheDay={menu}
+                            onFocus={() => {
+                                setFocusedDay(index);
+                            }}
+                            isCurrentDay={focusedDay === index}
                         />)
                     })}
+                </Box>
+                <Box>
+                    {Boolean(!isSmallView) && (<div className="menu-selected-day">
+                        <Heading as="h2">{Localisation.MENU_OF_THE_DAY}</Heading>
+                        {focusedRecipes.length === 0 && <div>{Localisation.NOTHING_PLANNED_TODAY}</div>}
+                        {focusedRecipes.map((data, index) => {
+                            return <div key={index}>{data.recipe.title}</div>
+                        })}
+                        <a ref={currentDayFocus} href='#' onClick={() => setIsOpened(true)}><FontAwesomeIcon icon={faPlus} />
+                            {Localisation.ADD}
+                        </a>
+                    </div>)}
+
+                    <AddMenyOverlay isOpened={isOpened}
+                        date={new Date(calculatedFocusedDay)}
+                        recipes={props.recipes}
+                        onSubmit={(selectedRecipe: Recipe) => {
+                            setIsOpened(false);
+                            props.addMenu({
+                                date: calculatedFocusedDay,
+                                recipe: selectedRecipe
+                            });
+                        }}
+                        onCancel={() => setIsOpened(false)} />
                 </Box>
             </Box>
         </SlideFade>
@@ -53,4 +132,4 @@ function MenuPlanner(props: Props) {
 }
 
 
-export default connect(mapStateToProps, { changeActiveView })(MenuPlanner);
+export default connect(mapStateToProps, { changeActiveView, addMenu })(MenuPlanner);

--- a/recipe-front-end/src/index.tsx
+++ b/recipe-front-end/src/index.tsx
@@ -33,10 +33,10 @@ async function start() {
   const store = createStore(handleState, {
     ...defaultState,
     menuPlanning: [{
-      date: new Date(2021, 0, 16).getTime(),
+      date: new Date(2021, 0, 18).getTime(),
       recipe: recipes[0]
     }, {
-      date: new Date(2021, 0, 17).getTime(),
+      date: new Date(2021, 0, 19).getTime(),
       recipe: recipes[1]
     }],
     recipes: replicatedSet,

--- a/recipe-front-end/src/localisation/AppTexts.ts
+++ b/recipe-front-end/src/localisation/AppTexts.ts
@@ -35,5 +35,7 @@ export enum Localisation {
     FRIDAY = 'Vrijdag',
     SATURDAY = 'Zaterdag',
     SUNDAY = 'Zondag',
-    DO_SEARCH = 'Zoeken maar'
+    DO_SEARCH = 'Zoeken maar',
+    MENU_OF_THE_DAY = 'Menu van de dag',
+    NOTHING_PLANNED_TODAY = 'Niets gepland vandaag.'
 }


### PR DESCRIPTION
Improve experience on wider screens: add the full details under the current week.

Main changes:
* better interface (showing more information, and possibility to add more details than the limited space previously available)
* better accessibility (with the width constraints lifted, names can now be read)
* allow navigation of days by using arrow keys (left, right)

Not 100% satisfied with code duplication, but this will be fixed tomorrow.