### PR TITLE
Improve mobile experience: extra animations, swiping between recipes

### DIFF
--- a/recipe-front-end/src/App.scss
+++ b/recipe-front-end/src/App.scss
@@ -129,11 +129,19 @@ html, body, #root {
 
 
 .recipe-overview-previous {
-  left: 1em;
+  left: 0em;
+
+  @media (min-width: 85em) {
+    left: 1em;
+  }
 }
 
 .recipe-overview-next {
-  right: 1em;
+  right: 0em;
+
+  @media (min-width: 85em) {
+    right: 1em;
+  }
 }
 
 .recipe-overview-previous,
@@ -142,6 +150,10 @@ html, body, #root {
   top: 50%;
   z-index: 10;
   display: none;
+
+  &.showTap {
+    display: block;
+  }
 
   @media (min-width: 85em) {
       display: block;

--- a/recipe-front-end/src/animations/AppearAnimation.tsx
+++ b/recipe-front-end/src/animations/AppearAnimation.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { motion } from 'framer-motion';
+
+interface OwnProps {
+    children: React.ReactNode;
+}
+
+export function AppearAnimation(props: OwnProps) {
+    return <motion.div initial={{ scale: 0.6 }}
+        animate={{ scale: 1 }}
+        transition={{ duration: 0.2 }}>
+        {props.children}
+    </motion.div>
+}

--- a/recipe-front-end/src/animations/BottomAppear.tsx
+++ b/recipe-front-end/src/animations/BottomAppear.tsx
@@ -5,7 +5,7 @@ interface OwnProps {
     children: React.ReactNode;
 }
 
-export function AnimatedAppear(props: OwnProps) {
+export function BottomAppear(props: OwnProps) {
     return <motion.div initial={{ scale: 0.8, originY: 30 }}
         animate={{ scale: 1, originY: 0 }}
         transition={{ duration: 0.5 }}>

--- a/recipe-front-end/src/components/common/ActionsContainer.tsx
+++ b/recipe-front-end/src/components/common/ActionsContainer.tsx
@@ -1,6 +1,7 @@
 import { useMediaQuery } from '@chakra-ui/react';
 import React from "react";
 import { connect } from 'react-redux';
+import { AppearAnimation } from '../../animations/AppearAnimation';
 import { ReduxModel } from '../../redux/Store';
 import UserMenuButton from '../account/UserMenuButton';
 import MenuPlannerButton from '../menu-planner/MenuPlannerButton';
@@ -23,13 +24,15 @@ function ActionsContainer(props: ReduxProps) {
     const [isBigScreen] = useMediaQuery("(min-width: 40em)");
     const showActions = !props.loggedIn || props.actionsOpened || isBigScreen;
 
-    return <div className='actionsContainer'>     
-        {!isBigScreen && props.loggedIn && <HamburgerMain isOpened={props.actionsOpened}/>}
-        {showActions && <div className='burger-more-options'>
-            <UserMenuButton />
-            <MenuPlannerButton />
-            <AddRecipeMenuButton />
-        </div>}
+    return <div className='actionsContainer'>
+        {!isBigScreen && props.loggedIn && <HamburgerMain isOpened={props.actionsOpened} />}
+        {showActions && <AppearAnimation>
+            <div className='burger-more-options'>
+                <UserMenuButton />
+                <MenuPlannerButton />
+                <AddRecipeMenuButton />
+            </div>
+        </AppearAnimation>}
     </div>
 }
 

--- a/recipe-front-end/src/components/common/AnimatedAppear.tsx
+++ b/recipe-front-end/src/components/common/AnimatedAppear.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { motion } from 'framer-motion';
+
+interface OwnProps {
+    children: React.ReactNode;
+}
+
+export function AnimatedAppear(props: OwnProps) {
+    return <motion.div initial={{ scale: 0.8, originY: 30 }}
+        animate={{ scale: 1, originY: 0 }}
+        transition={{ duration: 0.5 }}>
+        {props.children}
+    </motion.div>
+}

--- a/recipe-front-end/src/components/common/HamburgerMain.tsx
+++ b/recipe-front-end/src/components/common/HamburgerMain.tsx
@@ -3,9 +3,9 @@ import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { connect } from 'react-redux';
+import { BottomAppear } from '../../animations/BottomAppear';
 import { Localisation } from '../../localisation/AppTexts';
 import { updateMobileFapOpened } from '../../redux/Actions';
-import { AnimatedAppear } from './AnimatedAppear';
 
 interface OwnProps {
     isOpened: boolean;
@@ -19,7 +19,7 @@ type Props = OwnProps & ReduxActions;
 
 function HamburgerMain(props: Props) {
     const label = props.isOpened ? Localisation.LESS_OPTIONS : Localisation.MORE_OPTIONS;
-    return <AnimatedAppear>
+    return <BottomAppear>
         <Tooltip label={label}>
             <button className='action-item'
                 onClick={() => props.updateMobileFapOpened(!props.isOpened)}
@@ -27,7 +27,7 @@ function HamburgerMain(props: Props) {
                 <FontAwesomeIcon icon={props.isOpened ? faTimes : faBars} />
             </button>
         </Tooltip>
-    </AnimatedAppear>
+    </BottomAppear>
 }
 
 export default connect(null, { updateMobileFapOpened })(HamburgerMain)

--- a/recipe-front-end/src/components/common/HamburgerMain.tsx
+++ b/recipe-front-end/src/components/common/HamburgerMain.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Localisation } from '../../localisation/AppTexts';
 import { updateMobileFapOpened } from '../../redux/Actions';
+import { AnimatedAppear } from './AnimatedAppear';
 
 interface OwnProps {
     isOpened: boolean;
@@ -18,13 +19,15 @@ type Props = OwnProps & ReduxActions;
 
 function HamburgerMain(props: Props) {
     const label = props.isOpened ? Localisation.LESS_OPTIONS : Localisation.MORE_OPTIONS;
-    return <Tooltip label={label}>
-        <button className='action-item' 
-        onClick={() => props.updateMobileFapOpened(!props.isOpened)}
-        aria-label={label}>
-            <FontAwesomeIcon icon={props.isOpened ? faTimes : faBars} />
-        </button>
-    </Tooltip>
+    return <AnimatedAppear>
+        <Tooltip label={label}>
+            <button className='action-item'
+                onClick={() => props.updateMobileFapOpened(!props.isOpened)}
+                aria-label={label}>
+                <FontAwesomeIcon icon={props.isOpened ? faTimes : faBars} />
+            </button>
+        </Tooltip>
+    </AnimatedAppear>
 }
 
 export default connect(null, { updateMobileFapOpened })(HamburgerMain)

--- a/recipe-front-end/src/components/recipe-displays/RecipeOverview.tsx
+++ b/recipe-front-end/src/components/recipe-displays/RecipeOverview.tsx
@@ -69,6 +69,11 @@ function RecipeOverview(props: Props) {
             setMoved(e.touches[0].clientX);
         }}
         onTouchEndCapture={(e) => {
+            if (!moved) {
+                // there was no movement
+                return;
+            }
+
             const xDifference = originalTouch - moved;
             const minimumMoveFactor = 50;
             if (xDifference > minimumMoveFactor) {

--- a/recipe-front-end/src/components/recipe-displays/RecipeOverview.tsx
+++ b/recipe-front-end/src/components/recipe-displays/RecipeOverview.tsx
@@ -27,7 +27,7 @@ function mapStateToProps(state: ReduxModel) {
 
 function RecipeOverview(props: Props) {
     const [originalTouch, setOriginalTouch] = useState(0);
-    const [moved, setMoved] = useState(0);
+    const [direction, setDirection] = useState<Direction>();
 
     useEffect(() => {
         function handleKeyPress(keyEvent: KeyboardEvent) {
@@ -66,30 +66,29 @@ function RecipeOverview(props: Props) {
                 return;
             }
 
-            setMoved(e.touches[0].clientX);
-        }}
-        onTouchEndCapture={(e) => {
-            if (!moved) {
-                // there was no movement
-                return;
-            }
-
-            const xDifference = originalTouch - moved;
+            const xDifference = originalTouch - e.touches[0].clientX;
             const minimumMoveFactor = 50;
+
             if (xDifference > minimumMoveFactor) {
-                props.switchActiveRecipe(Direction.NEXT);
+                setDirection(Direction.NEXT);
             } else if (xDifference < -minimumMoveFactor) {
-                props.switchActiveRecipe(Direction.PREVIOUS);
+                setDirection(Direction.PREVIOUS);
+            }
+        }}
+        onTouchEndCapture={() => {
+            if (direction !== undefined) {
+                props.switchActiveRecipe(direction);
             }
 
             setOriginalTouch(0);
-            setMoved(0);
+            setDirection(0);
+            setDirection(undefined);
         }}
     ><ContentContainer>
-            <a className="recipe-overview-previous" href="#" onClick={() => props.switchActiveRecipe(Direction.PREVIOUS)} >
+            <a className={`recipe-overview-previous ${direction === Direction.PREVIOUS ? 'showTap' : ''}`} href="#" onClick={() => props.switchActiveRecipe(Direction.PREVIOUS)} >
                 <ArrowBackIcon boxSize="2em" aria-label={Localisation.PREVIOUS_RECIPE} />
             </a>
-            <a className="recipe-overview-next" href="#" onClick={() => props.switchActiveRecipe(Direction.NEXT)}>
+            <a className={`recipe-overview-next ${direction === Direction.NEXT ? 'showTap' : ''}`} href="#" onClick={() => props.switchActiveRecipe(Direction.NEXT)}>
                 <ArrowForwardIcon boxSize="2em" aria-label={Localisation.NEXT_RECIPE} />
             </a>
             <Heading as="h2">{props.recipe.title}</Heading>


### PR DESCRIPTION
Add more animations  using framer motion.
Allow swiping between recipes.
Show direction arrow when tap-dragging previous/next recipe for visual cue.