### PR TITLE
Store shopping range locally

### DIFF
--- a/recipe-front-end/src/index.tsx
+++ b/recipe-front-end/src/index.tsx
@@ -64,7 +64,8 @@ function findMenu(menu: RawDayMenu, recipes: Recipe[]): DayMenu | undefined {
 
 
   const shoppingRangeFromStorage = localStorage.getItem(LOCAL_STORAGE_RANGE_NAME);
-  const shoppingDateRange = parseDateRange(shoppingRangeFromStorage) || defaultState.shoppingDateRange;
+  const shoppingDateRange = parseDateRange(shoppingRangeFromStorage, Number(new Date()))
+    || defaultState.shoppingDateRange;
 
   const store = createStore(handleState, {
     ...defaultState,

--- a/recipe-front-end/src/index.tsx
+++ b/recipe-front-end/src/index.tsx
@@ -8,10 +8,11 @@ import App from "./App";
 import { ApplicationData, RawDayMenu, Recipe } from "./interfaces/Recipe";
 import { BackEndUserData } from "./interfaces/UserData";
 import { DayMenu, defaultState, handleState } from './redux/Store';
-import { calculateStartOfDate } from "./utils/DateUtils";
+import { calculateStartOfDate, parseDateRange } from "./utils/DateUtils";
 import { parseGetParams } from "./utils/UrlUtils";
 import { BrowserRouter as Router } from 'react-router-dom';
 import fetchGraphQL from './utils/FetchGraphQL';
+import { LOCAL_STORAGE_RANGE_NAME } from './redux/Actions';
 
 function findMenu(menu: RawDayMenu, recipes: Recipe[]): DayMenu | undefined {
   const entry = recipes.filter((recipe) => recipe.id === menu.recipeId)[0];
@@ -61,8 +62,13 @@ function findMenu(menu: RawDayMenu, recipes: Recipe[]): DayMenu | undefined {
     .map((menu) => findMenu(menu, applicationData.recipes))
     .filter((value) => value !== undefined) as DayMenu[];
 
+
+  const shoppingRangeFromStorage = localStorage.getItem(LOCAL_STORAGE_RANGE_NAME);
+  const shoppingDateRange = parseDateRange(shoppingRangeFromStorage) || defaultState.shoppingDateRange;
+
   const store = createStore(handleState, {
     ...defaultState,
+    ...{ shoppingDateRange },
     user: {
       loggedIn: userData.loggedIn,
       name: userData.userName

--- a/recipe-front-end/src/redux/Actions.ts
+++ b/recipe-front-end/src/redux/Actions.ts
@@ -142,7 +142,10 @@ export function updateMobileFapOpened(isOpened: boolean): UpdateMobileFapOpenedA
     }
 }
 
+export const LOCAL_STORAGE_RANGE_NAME = 'shopping-range';
 export function updateShoppingRange(range: DateRange): UpdateShoppingRangeAction {
+    localStorage.setItem(LOCAL_STORAGE_RANGE_NAME, JSON.stringify(range));
+
     return {
         type: Actions.UPDATE_SHOPPING_RANGE,
         range

--- a/recipe-front-end/src/redux/Actions.ts
+++ b/recipe-front-end/src/redux/Actions.ts
@@ -144,7 +144,10 @@ export function updateMobileFapOpened(isOpened: boolean): UpdateMobileFapOpenedA
 
 export const LOCAL_STORAGE_RANGE_NAME = 'shopping-range';
 export function updateShoppingRange(range: DateRange): UpdateShoppingRangeAction {
-    localStorage.setItem(LOCAL_STORAGE_RANGE_NAME, JSON.stringify(range));
+    localStorage.setItem(LOCAL_STORAGE_RANGE_NAME, JSON.stringify({
+        start: Number(range.start),
+        end: Number(range.end)
+    }));
 
     return {
         type: Actions.UPDATE_SHOPPING_RANGE,

--- a/recipe-front-end/src/redux/Actions.ts
+++ b/recipe-front-end/src/redux/Actions.ts
@@ -144,10 +144,12 @@ export function updateMobileFapOpened(isOpened: boolean): UpdateMobileFapOpenedA
 
 export const LOCAL_STORAGE_RANGE_NAME = 'shopping-range';
 export function updateShoppingRange(range: DateRange): UpdateShoppingRangeAction {
-    localStorage.setItem(LOCAL_STORAGE_RANGE_NAME, JSON.stringify({
-        start: Number(range.start),
-        end: Number(range.end)
-    }));
+    if (Number(range.end) > Number(new Date())) {
+        localStorage.setItem(LOCAL_STORAGE_RANGE_NAME, JSON.stringify({
+            start: Number(range.start),
+            end: Number(range.end)
+        }));    
+    }
 
     return {
         type: Actions.UPDATE_SHOPPING_RANGE,

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -74,13 +74,18 @@ export function dateIsInRange(dateToCompare: Date, fromDate: Date, toDate: Date)
         calculateStartOfDate(toDate) >= calculateStartOfDate(dateToCompare);
 }
 
-export function parseDateRange(input: string | null): DateRange | undefined {
+export function parseDateRange(input: string | null, now: number): DateRange | undefined {
     if (!input) {
         return undefined;
     }
 
     try {
         const parsedInput: {start: number, end: number} = JSON.parse(input);
+
+        if (now > Number(new Date(parsedInput.end))) {
+            return undefined;
+        }
+
         return {
             start: new Date(parsedInput.start),
             end: new Date(parsedInput.end)

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -1,3 +1,5 @@
+import { DateRange } from '../redux/Store';
+
 export const FULL_DAY_IN_MS = 24 * 60 * 60 * 1e3;
 
 export function calculateStartOfDate(date: Date) {
@@ -70,4 +72,20 @@ export function addDays(date: Date, days: number): Date {
 export function dateIsInRange(dateToCompare: Date, fromDate: Date, toDate: Date): boolean {
     return calculateStartOfDate(fromDate) <= calculateStartOfDate(dateToCompare) &&
         calculateStartOfDate(toDate) >= calculateStartOfDate(dateToCompare);
+}
+
+export function parseDateRange(input: string | null): DateRange | undefined {
+    if (!input) {
+        return undefined;
+    }
+
+    try {
+        const parsedInput: {start: number, end: number} = JSON.parse(input);
+        return {
+            start: new Date(parsedInput.start),
+            end: new Date(parsedInput.end)
+        }
+    } catch (err) {
+        return undefined;
+    }
 }

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -82,7 +82,7 @@ export function parseDateRange(input: string | null, now: number): DateRange | u
     try {
         const parsedInput: {start: number, end: number} = JSON.parse(input);
 
-        if (now > Number(new Date(parsedInput.end))) {
+        if (now > parsedInput.end) {
             return undefined;
         }
 


### PR DESCRIPTION
Store shopping range in LocalStorage so it can be easily retrieved later on.

Business rules:
* when no custom range is configured, use the default (current date until current date + 7 days).
* when a custom range is configured, it shall only be stored when the end-date is in the future (Redux-model allows the change in the single-page application, to prevent breaking the application)
* When the current time is past the end date, the default value applies.