### PR TITLE
Improve recipe grid

### DIFF
--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
@@ -11,23 +11,33 @@
 .recipeBox {
   position: relative;
 
-  .grid-image::before {
-    content: '';
+  .grid-image {
+    position: absolute;
+    left: 0;
+    top: 0;
     width: 100%;
     height: 100%;
-    box-shadow: inset 0em 0em 0em rgba(51, 51, 51, 0.15);
-  }
+    
+    &::before {
+      content: '';
+      width: 100%;
+      height: 100%;
+    }
+}
 
   a:hover,
   a:focus {
-    .grid-image,
-    .grid-image {
-      filter: opacity(0.95);
+    .aspect-ratio {
+      overflow: hidden;
+    }
 
-      &:before {
-        box-shadow: inset 0.5em 0.5em 0.5em rgba(0, 0, 0, 0.15);
-        transition: box-shadow 0.3s;
-      }
+    .grid-image {
+      left: -0.5em;
+      top: -0.5em;
+      width: calc(100% + 1em);
+      height: calc(100% + 1em);
+
+      transition: all 0.15s ease-in;
     }
   }
 }

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
@@ -11,11 +11,23 @@
 .recipeBox {
   position: relative;
 
+  .grid-image::before {
+    content: '';
+    width: 100%;
+    height: 100%;
+    box-shadow: inset 0em 0em 0em rgba(51, 51, 51, 0.15);
+  }
+
   a:hover,
   a:focus {
     .grid-image,
     .grid-image {
-      filter: opacity(0.85);
+      filter: opacity(0.95);
+
+      &:before {
+        box-shadow: inset 0.5em 0.5em 0.5em rgba(0, 0, 0, 0.15);
+        transition: box-shadow 0.3s;
+      }
     }
   }
 }

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
@@ -11,8 +11,8 @@
   .recipeBox {
     position: relative;
   
-    a:hover img,
-    a:focus img {
+    a:hover .grid-image,
+    a:focus .grid-image {
       filter: opacity(0.85);
     }
   }

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
@@ -11,8 +11,11 @@
   .recipeBox {
     position: relative;
   
-    a:hover .grid-image,
-    a:focus .grid-image {
-      filter: opacity(0.85);
+    a:hover,
+    a:focus {
+      .grid-image,
+      .grid-image {
+        filter: opacity(0.85);
+      }
     }
   }

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.scss
@@ -1,21 +1,21 @@
 .recipe-preview-size {
-    position: absolute;
-    font-size: 1.7em;
-    top: 0.8em;
-    left: 0.8em;
-    z-index: 9;
-    color: white;
-    text-shadow: 1px 1px 3px black;
-  }
+  position: absolute;
+  font-size: 1.7em;
+  top: 0.8em;
+  left: 0.8em;
+  z-index: 9;
+  color: white;
+  text-shadow: 1px 1px 3px black;
+}
 
-  .recipeBox {
-    position: relative;
-  
-    a:hover,
-    a:focus {
-      .grid-image,
-      .grid-image {
-        filter: opacity(0.85);
-      }
+.recipeBox {
+  position: relative;
+
+  a:hover,
+  a:focus {
+    .grid-image,
+    .grid-image {
+      filter: opacity(0.85);
     }
   }
+}

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
@@ -16,13 +16,10 @@ export default function RecipePreview(props: OwnProps) {
     borderRadius="lg"
   ><Link to={`${Paths.RECIPE_OVERVIEW}/${props.recipe.id}`}>
       <strong className="recipe-preview-size">{props.recipe.title}</strong>
-      <AspectRatio ratio={1}>
+      <AspectRatio className="aspect-ratio" ratio={1}>
         <div className="grid-image" style={{
           backgroundImage: `url(${props.recipe.image})`,
-          backgroundSize: 'cover',
-          width: "100%",
-          height: "100%"
-          
+          backgroundSize: 'cover'
         }}></div>
       </AspectRatio>
     </Link>

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
@@ -17,7 +17,7 @@ export default function RecipePreview(props: OwnProps) {
   ><Link to={`${Paths.RECIPE_OVERVIEW}/${props.recipe.id}`}>
       <strong className="recipe-preview-size">{props.recipe.title}</strong>
       <AspectRatio ratio={1}>
-        <div style={{
+        <div className="grid-image" style={{
           backgroundImage: `url(${props.recipe.image})`,
           backgroundSize: 'cover',
           width: "100%",

--- a/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
+++ b/recipe-front-end/src/components/recipe-displays/RecipePreview.tsx
@@ -1,4 +1,4 @@
-import { Box, Image } from "@chakra-ui/react";
+import { AspectRatio, Box, Image } from "@chakra-ui/react";
 import React from "react";
 import { Link } from "react-router-dom";
 import { Recipe } from "../../interfaces/Recipe";
@@ -16,7 +16,15 @@ export default function RecipePreview(props: OwnProps) {
     borderRadius="lg"
   ><Link to={`${Paths.RECIPE_OVERVIEW}/${props.recipe.id}`}>
       <strong className="recipe-preview-size">{props.recipe.title}</strong>
-      <Image src={props.recipe.image} width="100%" alt="" />
+      <AspectRatio ratio={1}>
+        <div style={{
+          backgroundImage: `url(${props.recipe.image})`,
+          backgroundSize: 'cover',
+          width: "100%",
+          height: "100%"
+          
+        }}></div>
+      </AspectRatio>
     </Link>
   </Box>);
 }


### PR DESCRIPTION
Use CSS-background + aspect ratio of 1:1 so image is always square.

Add a small zoom-effect when hovering / focusing an item.