### PR TITLE
Limit calendar key input range

### DIFF
--- a/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
+++ b/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
@@ -50,7 +50,7 @@ function MenuPlanner(props: Props) {
     const currentWeekDay = normalizeWeekDay(currentDay.getUTCDay());
     const firstDayOfCurrentWeek = addDays(currentDay, -currentWeekDay);
     const firstDayOfNextWeek = addDays(firstDayOfCurrentWeek, 7);
-    const maximumRange = addDays(firstDayOfCurrentWeek, 14);
+    const maximumRange = addDays(firstDayOfCurrentWeek, 13);
     const [isSmallView] = useMediaQuery("(max-width: 40em)");
     const [isOpened, setIsOpened] = useState(false);
     const currentDayFocus = useRef<HTMLAnchorElement>(null);

--- a/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
+++ b/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
@@ -66,9 +66,9 @@ function MenuPlanner(props: Props) {
 
             let activeDay = props.activeDay ? new Date(props.activeDay) : firstDayOfCurrentWeek;
             if (event.code === 'ArrowLeft') {
-                activeDay = new Date(Math.max(activeDay.getTime() - FULL_DAY_IN_MS, firstDayOfCurrentWeek.getTime()));
+                activeDay = new Date(Math.max(addDays(activeDay, -1).getTime(), firstDayOfCurrentWeek.getTime()));
             } else if (event.code === 'ArrowRight') {
-                activeDay = new Date(Math.min(activeDay.getTime() + FULL_DAY_IN_MS, maximumRange.getTime()));
+                activeDay = new Date(Math.min(addDays(activeDay, 1).getTime(), maximumRange.getTime()));
             } else {
                 return;
             }

--- a/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
+++ b/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
@@ -8,7 +8,7 @@ import { Localisation } from "../../localisation/AppTexts";
 import { Paths } from '../../Paths';
 import { updateActiveDay } from '../../redux/Actions';
 import { DayMenu, ReduxModel } from "../../redux/Store";
-import { addDays, calculateStartOfDate, FULL_DAY_IN_MS, normalizeWeekDay } from "../../utils/DateUtils";
+import { addDays, calculateStartOfDate, clipDate, FULL_DAY_IN_MS, normalizeWeekDay } from "../../utils/DateUtils";
 import ContentContainer from "../common/ContentContainer";
 import AddMenuOverlay from "./AddMenuOverlay";
 import DayDetails from "./DayDetails";
@@ -66,9 +66,9 @@ function MenuPlanner(props: Props) {
 
             let activeDay = props.activeDay ? new Date(props.activeDay) : firstDayOfCurrentWeek;
             if (event.code === 'ArrowLeft') {
-                activeDay = new Date(Math.max(addDays(activeDay, -1).getTime(), firstDayOfCurrentWeek.getTime()));
+                activeDay = clipDate(addDays(activeDay, -1), firstDayOfCurrentWeek, Math.max);
             } else if (event.code === 'ArrowRight') {
-                activeDay = new Date(Math.min(addDays(activeDay, 1).getTime(), maximumRange.getTime()));
+                activeDay = clipDate(addDays(activeDay, 1), maximumRange, Math.min);
             } else {
                 return;
             }

--- a/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
+++ b/recipe-front-end/src/components/menu-planner/MenuPlanner.tsx
@@ -65,16 +65,20 @@ function MenuPlanner(props: Props) {
             }
 
             let activeDay = props.activeDay ? new Date(props.activeDay) : firstDayOfCurrentWeek;
+            let offset = 0;
+
             if (event.code === 'ArrowLeft') {
-                activeDay = clipDate(addDays(activeDay, -1), firstDayOfCurrentWeek, Math.max);
+                offset = -1;
             } else if (event.code === 'ArrowRight') {
-                activeDay = clipDate(addDays(activeDay, 1), maximumRange, Math.min);
-            } else {
-                return;
+                offset = 1;
             }
 
-            currentDayFocus.current?.focus();
-            props.updateActiveDay(activeDay.getTime());
+            if (offset) {
+                activeDay = clipDate(addDays(activeDay, offset), firstDayOfCurrentWeek, maximumRange);
+                currentDayFocus.current?.focus();
+                props.updateActiveDay(activeDay.getTime());   
+            } 
+
         }
 
         document.body.addEventListener('keyup', switchDay);

--- a/recipe-front-end/src/components/menu-planner/Week.tsx
+++ b/recipe-front-end/src/components/menu-planner/Week.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { Localisation } from "../../localisation/AppTexts";
 import { updateActiveDay } from "../../redux/Actions";
-import { addDays, calculateStartOfDate, FULL_DAY_IN_MS } from "../../utils/DateUtils";
+import { addDays } from "../../utils/DateUtils";
 import Day from "./Day";
 import DayDetails from "./DayDetails";
 import "./Week.scss";

--- a/recipe-front-end/src/components/range-picker/RangePicker.tsx
+++ b/recipe-front-end/src/components/range-picker/RangePicker.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, useState } from 'react';
 import { DateRange } from '../../redux/Store';
-import { addDays, calculateStartOfDate, calculateStartOfMonthWithOffset, clipDate, FULL_DAY_IN_MS } from '../../utils/DateUtils';
+import { addDays, calculateStartOfMonthWithOffset, clipDate, FULL_DAY_IN_MS } from '../../utils/DateUtils';
 import { CalendarMonth } from './CalendarMonth';
 import { FillDayFilter } from './dayfilters/FillDayFilter';
 

--- a/recipe-front-end/src/components/range-picker/RangePicker.tsx
+++ b/recipe-front-end/src/components/range-picker/RangePicker.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, useState } from 'react';
 import { DateRange } from '../../redux/Store';
-import { addDays, calculateStartOfMonthWithOffset } from '../../utils/DateUtils';
+import { addDays, calculateStartOfDate, calculateStartOfMonthWithOffset, FULL_DAY_IN_MS } from '../../utils/DateUtils';
 import { CalendarMonth } from './CalendarMonth';
 import { FillDayFilter } from './dayfilters/FillDayFilter';
 
@@ -51,14 +51,18 @@ export default function RangePicker(props: Props) {
                 // ignore
         }
 
-        let assigned: Date;
+        let calculatedNewDay: Date;
         
         if (daysToAdd) {
-            assigned = addDays(props.activeDay, daysToAdd)
-            props.onDaySelected(assigned);
+            calculatedNewDay = addDays(props.activeDay, daysToAdd);
+
+            const clippedTime = Math.min(
+                endRange.getTime(), 
+                Math.max(months[0].getTime(), calculatedNewDay.getTime())
+            );
+            const clippedDate = calculateStartOfDate(new Date(clippedTime));
+            props.onDaySelected(clippedDate);
         }
-
-
 
         if (key === 'Enter' && initialOpen) {
             props.onDayPicked(props.activeDay);
@@ -76,6 +80,8 @@ export default function RangePicker(props: Props) {
     if (props.showNextMonth) {
         months.push(calculateStartOfMonthWithOffset(months[0], 1));
     }
+
+    const endRange = new Date(calculateStartOfMonthWithOffset(months[months.length - 1], 1).getTime() - FULL_DAY_IN_MS);
 
     return <DatePickerContext.Provider value={props.selectedRange}>
         <div className="date-picker" tabIndex={-1} ref={props.initialFocusRef} onKeyUpCapture={(event) => {

--- a/recipe-front-end/src/components/range-picker/RangePicker.tsx
+++ b/recipe-front-end/src/components/range-picker/RangePicker.tsx
@@ -70,11 +70,11 @@ export default function RangePicker(props: Props) {
     }
 
     const months = [
-        new Date()
+        calculateStartOfMonthWithOffset(new Date(), 0)
     ]
 
     if (props.showNextMonth) {
-        months.push(calculateStartOfMonthWithOffset(new Date(), 1));
+        months.push(calculateStartOfMonthWithOffset(months[0], 1));
     }
 
     return <DatePickerContext.Provider value={props.selectedRange}>

--- a/recipe-front-end/src/components/range-picker/RangePicker.tsx
+++ b/recipe-front-end/src/components/range-picker/RangePicker.tsx
@@ -1,6 +1,6 @@
 import React, { KeyboardEvent, useState } from 'react';
 import { DateRange } from '../../redux/Store';
-import { addDays, calculateStartOfDate, calculateStartOfMonthWithOffset, FULL_DAY_IN_MS } from '../../utils/DateUtils';
+import { addDays, calculateStartOfDate, calculateStartOfMonthWithOffset, clipDate, FULL_DAY_IN_MS } from '../../utils/DateUtils';
 import { CalendarMonth } from './CalendarMonth';
 import { FillDayFilter } from './dayfilters/FillDayFilter';
 
@@ -55,12 +55,7 @@ export default function RangePicker(props: Props) {
         
         if (daysToAdd) {
             calculatedNewDay = addDays(props.activeDay, daysToAdd);
-
-            const clippedTime = Math.min(
-                endRange.getTime(), 
-                Math.max(months[0].getTime(), calculatedNewDay.getTime())
-            );
-            const clippedDate = calculateStartOfDate(new Date(clippedTime));
+            const clippedDate = clipDate(calculatedNewDay, months[0], endRange);
             props.onDaySelected(clippedDate);
         }
 

--- a/recipe-front-end/src/components/recipe-management/IngredientsModal.tsx
+++ b/recipe-front-end/src/components/recipe-management/IngredientsModal.tsx
@@ -70,7 +70,7 @@ function IngredientsModal(props: Props) {
                 <label>
                     {Localisation.CATEGORY_INGREDIENT}
                     <Select defaultValue={props.categories[0].categoryId} onChange={(e) => setCategoryId(Number(e.target.selectedOptions[0].value))}>
-                        {props.categories.map((category, index) => {
+                        {props.categories.map((category) => {
                             return <React.Fragment key={category.categoryId}>
                                 <option value={category.categoryId}>
                                     {translateCategory(category.categoryName as any)}

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -95,7 +95,11 @@ export function parseDateRange(input: string | null, now: number): DateRange | u
     }
 }
 
-export function clipDate(firstDate: Date, secondDate: Date, comparator: (...numbers: number[]) => number): Date {
-    const result = comparator(firstDate.getTime(), secondDate.getTime());
-    return new Date(result);
+export function clipDate(dateToClip: Date, minimumRange: Date, maximumRange: Date): Date {
+    const clippedTime = Math.min(
+        maximumRange.getTime(), 
+        Math.max(minimumRange.getTime(), dateToClip.getTime())
+    );
+    
+    return new Date(clippedTime);
 }

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -7,7 +7,7 @@ export function calculateStartOfDate(date: Date) {
 }
 
 export function calculateStartOfMonthWithOffset(date: Date, offset: number) {
-    return new Date(date.getFullYear(), date.getMonth() + offset, 1);
+    return new Date(Date.UTC(date.getFullYear(), date.getMonth() + offset, 1));
 }
 
 export function normalizeWeekDay(day: number): number {

--- a/recipe-front-end/src/utils/DateUtils.ts
+++ b/recipe-front-end/src/utils/DateUtils.ts
@@ -94,3 +94,8 @@ export function parseDateRange(input: string | null, now: number): DateRange | u
         return undefined;
     }
 }
+
+export function clipDate(firstDate: Date, secondDate: Date, comparator: (...numbers: number[]) => number): Date {
+    const result = comparator(firstDate.getTime(), secondDate.getTime());
+    return new Date(result);
+}


### PR DESCRIPTION
Using navigation keys, one can leave the intended range. This pull request fixes this.